### PR TITLE
Update cycle labels and pointer styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -241,6 +241,17 @@ svg {
   transform: scale(1.04);
 }
 
+.day-circle {
+  fill: #fff;
+  stroke: rgba(0, 0, 0, 0.08);
+  stroke-width: 1;
+}
+
+body.dark .day-circle {
+  fill: #111;
+  stroke: rgba(255, 255, 255, 0.18);
+}
+
 .day-label {
   font-size: clamp(11px, 1.4vw, 13px);
   text-anchor: middle;
@@ -281,14 +292,16 @@ svg {
 .cycle-band.five { stroke: var(--legend-five); }
 .cycle-band.seven { stroke: var(--legend-seven); }
 
-.pointer {
-  stroke: var(--today-color);
-  stroke-width: 3;
-  stroke-linecap: round;
+.pointer-group {
+  pointer-events: none;
 }
 
-.pointer-tip {
+.pointer-triangle {
   fill: var(--today-color);
+  fill-opacity: 0.18;
+  stroke: var(--today-color);
+  stroke-width: 2;
+  stroke-linejoin: round;
 }
 
 .fallback-list {

--- a/index.html
+++ b/index.html
@@ -33,29 +33,29 @@
           <dd id="detail-date">-</dd>
         </div>
         <div>
-          <dt>二日周期</dt>
+          <dt class="sr-only">二日周期</dt>
           <dd id="detail-two">-</dd>
         </div>
         <div>
-          <dt>三日周期</dt>
+          <dt class="sr-only">三日周期</dt>
           <dd id="detail-three">-</dd>
         </div>
         <div>
-          <dt>五日周期</dt>
+          <dt class="sr-only">五日周期</dt>
           <dd id="detail-five">-</dd>
         </div>
         <div>
-          <dt>七日周期</dt>
+          <dt class="sr-only">七日周期</dt>
           <dd id="detail-seven">-</dd>
         </div>
       </dl>
       <section class="legend" aria-labelledby="legend-heading">
         <h3 id="legend-heading">凡例</h3>
         <ul>
-          <li><span class="legend-dot legend-two" aria-hidden="true"></span><span>[二] 子・午</span></li>
-          <li><span class="legend-dot legend-three" aria-hidden="true"></span><span>[三] 子・辰・申</span></li>
-          <li><span class="legend-dot legend-five" aria-hidden="true"></span><span>[五] 甲・丙・戊・庚・壬</span></li>
-          <li><span class="legend-dot legend-seven" aria-hidden="true"></span><span>[七] 日・月・火・水・木・金・土</span></li>
+          <li><span class="legend-dot legend-two" aria-hidden="true"></span><span>二日周期: 陰・陽</span></li>
+          <li><span class="legend-dot legend-three" aria-hidden="true"></span><span>三日周期: 石・鋏・紙</span></li>
+          <li><span class="legend-dot legend-five" aria-hidden="true"></span><span>五日周期: 風・雨・雷・雲・霧</span></li>
+          <li><span class="legend-dot legend-seven" aria-hidden="true"></span><span>七日周期: 日・月・火・水・木・金・土</span></li>
         </ul>
       </section>
       <p class="help-text">基準日 1980-01-01 からの暦日差で周期を計算しています。</p>

--- a/js/app.js
+++ b/js/app.js
@@ -1,15 +1,15 @@
 (function () {
   const baseDate = new Date(1980, 0, 1);
-  const twoCycle = ['子', '午'];
-  const threeCycle = ['子', '辰', '申'];
-  const fiveCycle = ['甲', '丙', '戊', '庚', '壬'];
+  const twoCycle = ['陰', '陽'];
+  const threeCycle = ['石', '鋏', '紙'];
+  const fiveCycle = ['風', '雨', '雷', '雲', '霧'];
   const sevenCycle = ['日', '月', '火', '水', '木', '金', '土'];
 
   const cycleMeta = {
-    2: { prefix: '[二]', names: twoCycle },
-    3: { prefix: '[三]', names: threeCycle },
-    5: { prefix: '[五]', names: fiveCycle },
-    7: { prefix: '[七]', names: sevenCycle }
+    2: { names: twoCycle },
+    3: { names: threeCycle },
+    5: { names: fiveCycle },
+    7: { names: sevenCycle }
   };
 
   const nowEl = document.getElementById('now');
@@ -78,7 +78,7 @@
 
   function cycleLabel(delta, n) {
     const idx = cycleIndex(delta, n);
-    return `${cycleMeta[n].prefix}${cycleMeta[n].names[idx]}曜`;
+    return cycleMeta[n].names[idx];
   }
 
   function render() {
@@ -209,21 +209,32 @@
 
       if (day === todayDay) {
         const angle = (2 * Math.PI * ((day - 0.5) / daysInMonth)) - Math.PI / 2;
-        const pointer = document.createElementNS(svgNS, 'line');
-        const pointerLength = radii.date + 36;
-        pointer.setAttribute('x1', center);
-        pointer.setAttribute('y1', center);
-        pointer.setAttribute('x2', center + pointerLength * Math.cos(angle));
-        pointer.setAttribute('y2', center + pointerLength * Math.sin(angle));
-        pointer.setAttribute('class', 'pointer');
-        pointerGroup.appendChild(pointer);
+        const wedgeWidth = (2 * Math.PI) / daysInMonth * 0.8;
+        const outerRadius = radii.date + 52;
+        const innerRadius = radii.date - 24;
 
-        const tip = document.createElementNS(svgNS, 'circle');
-        tip.setAttribute('cx', center + (pointerLength + 6) * Math.cos(angle));
-        tip.setAttribute('cy', center + (pointerLength + 6) * Math.sin(angle));
-        tip.setAttribute('r', 4);
-        tip.setAttribute('class', 'pointer-tip');
-        pointerGroup.appendChild(tip);
+        const points = [
+          {
+            x: center + outerRadius * Math.cos(angle - wedgeWidth / 2),
+            y: center + outerRadius * Math.sin(angle - wedgeWidth / 2)
+          },
+          {
+            x: center + innerRadius * Math.cos(angle),
+            y: center + innerRadius * Math.sin(angle)
+          },
+          {
+            x: center + outerRadius * Math.cos(angle + wedgeWidth / 2),
+            y: center + outerRadius * Math.sin(angle + wedgeWidth / 2)
+          }
+        ];
+
+        const polygon = document.createElementNS(svgNS, 'polygon');
+        polygon.setAttribute(
+          'points',
+          points.map(({ x, y }) => `${x},${y}`).join(' ')
+        );
+        polygon.setAttribute('class', 'pointer-triangle');
+        pointerGroup.appendChild(polygon);
       }
 
       dayGroup.addEventListener('click', handleDaySelection);
@@ -256,12 +267,6 @@
   }
 
   function shrinkLabel(label) {
-    if (window.innerWidth < 360) {
-      return label.replace(/\[(.)\]./, '$1');
-    }
-    if (window.innerWidth < 420) {
-      return label.replace(/\[(.)\]/, '$1:').replace('曜', '');
-    }
     return label;
   }
 


### PR DESCRIPTION
## Summary
- replace the 2/3/5-day cycle names with the requested kanji and drop the bracketed prefixes across the UI
- hide the detail panel headings while keeping accessible labels and refresh the legend wording
- restyle the day cells and replace the line pointer with a triangular wedge that surrounds today’s date

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1458a1dc0833185cc8082eea7b68a