### PR TITLE
Add legend toggle and align colors

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -98,6 +98,38 @@ body {
   align-self: start;
 }
 
+.legend-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.legend-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.legend-toggle {
+  border: 1px solid var(--ring-border);
+  background: white;
+  color: inherit;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.legend-toggle:hover,
+.legend-toggle:focus-visible {
+  background-color: #f0f4ff;
+  outline: none;
+  transform: translateY(-1px);
+}
+
 .legend ul {
   list-style: none;
   margin: 0;
@@ -123,6 +155,49 @@ body {
 .legend-three { background: var(--legend-three); }
 .legend-five { background: var(--legend-five); }
 .legend-seven { background: var(--legend-seven); }
+
+.legend-panel.is-hidden {
+  background: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+.legend-panel.is-hidden .legend {
+  display: none;
+}
+
+.legend-panel.is-hidden .legend-header {
+  justify-content: flex-end;
+  margin-bottom: 0;
+}
+
+.legend-panel.is-hidden .legend-header h3 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.legend-panel.is-hidden .legend-toggle {
+  background: transparent;
+  border-color: transparent;
+  padding: 0.4rem 0.9rem;
+}
+
+.legend-panel.is-hidden .legend-toggle:hover,
+.legend-panel.is-hidden .legend-toggle:focus-visible {
+  background-color: rgba(240, 244, 255, 0.7);
+  border-color: var(--ring-border);
+}
+
+.app-main.legend-hidden {
+  grid-template-columns: 1fr;
+}
 
 .app-footer {
   font-size: 0.8rem;
@@ -200,6 +275,27 @@ body.dark .controls button:focus-visible {
   background: rgba(255, 255, 255, 0.1);
 }
 
+body.dark .legend-toggle {
+  background: rgba(0, 0, 0, 0.2);
+  color: #f5f5f5;
+}
+
+body.dark .legend-toggle:hover,
+body.dark .legend-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+body.dark .legend-panel.is-hidden .legend-toggle {
+  background: transparent;
+  border-color: transparent;
+}
+
+body.dark .legend-panel.is-hidden .legend-toggle:hover,
+body.dark .legend-panel.is-hidden .legend-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
 body.dark .app-footer {
   color: rgba(255, 255, 255, 0.7);
 }
@@ -242,6 +338,22 @@ body.dark .day-circle {
   text-anchor: middle;
   dominant-baseline: middle;
   fill: var(--text-muted);
+}
+
+.sub-label.legend-two {
+  fill: var(--legend-two);
+}
+
+.sub-label.legend-three {
+  fill: var(--legend-three);
+}
+
+.sub-label.legend-five {
+  fill: var(--legend-five);
+}
+
+.sub-label.legend-seven {
+  fill: var(--legend-seven);
 }
 
 .today-circle {

--- a/index.html
+++ b/index.html
@@ -26,9 +26,14 @@
       <div id="fallback-list" class="sr-only"></div>
     </section>
     <aside class="legend-panel" aria-labelledby="legend-heading">
-      <section class="legend" aria-labelledby="legend-heading">
+      <div class="legend-header">
         <h3 id="legend-heading">凡例</h3>
-        <ul>
+        <button id="legend-toggle" class="legend-toggle" type="button" aria-controls="legend-list" aria-expanded="true">
+          凡例を隠す
+        </button>
+      </div>
+      <section class="legend" aria-labelledby="legend-heading">
+        <ul id="legend-list">
           <li><span class="legend-dot legend-two" aria-hidden="true"></span><span>二日周期: 陰・陽</span></li>
           <li><span class="legend-dot legend-three" aria-hidden="true"></span><span>三日周期: 石・鋏・紙</span></li>
           <li><span class="legend-dot legend-five" aria-hidden="true"></span><span>五日周期: 風・雨・雷・雲・霧</span></li>

--- a/js/app.js
+++ b/js/app.js
@@ -21,11 +21,20 @@
   const nextBtn = document.getElementById('next');
   const todayBtn = document.getElementById('today');
 
+  const legendPanel = document.querySelector('.legend-panel');
+  const legendToggle = document.getElementById('legend-toggle');
+  const legendSection = document.querySelector('.legend');
+  const appMain = document.querySelector('.app-main');
+
   const state = {
     today: new Date(),
     viewYear: 0,
     viewMonth: 0,
     selectedDate: null
+  };
+
+  const legendState = {
+    hidden: false
   };
 
   function startClock() {
@@ -386,5 +395,35 @@
     startClock();
     initState();
     render();
+    if (legendToggle) {
+      legendToggle.addEventListener('click', () => {
+        legendState.hidden = !legendState.hidden;
+        updateLegendVisibility();
+        render();
+      });
+      updateLegendVisibility();
+    }
   });
+
+  function updateLegendVisibility() {
+    if (!legendPanel || !legendToggle || !appMain) {
+      return;
+    }
+    legendPanel.classList.toggle('is-hidden', legendState.hidden);
+    appMain.classList.toggle('legend-hidden', legendState.hidden);
+    legendToggle.setAttribute('aria-expanded', String(!legendState.hidden));
+    legendToggle.textContent = legendState.hidden ? '凡例を表示' : '凡例を隠す';
+    legendToggle.setAttribute('aria-label', legendState.hidden ? '凡例を表示' : '凡例を隠す');
+    if (legendSection) {
+      if (legendState.hidden) {
+        legendSection.setAttribute('aria-hidden', 'true');
+        legendSection.setAttribute('inert', '');
+        legendSection.hidden = true;
+      } else {
+        legendSection.removeAttribute('aria-hidden');
+        legendSection.removeAttribute('inert');
+        legendSection.hidden = false;
+      }
+    }
+  }
 })();


### PR DESCRIPTION
## Summary
- add a legend visibility toggle that collapses the legend panel and reclaims calendar space
- tweak styles so collapsed legends remain accessible and the toggle works in dark mode
- colorize cycle labels inside the ring to match the legend colors

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d153c44f488331b59c1f69947313a6