### PR TITLE
Adjust month label typography

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -244,11 +244,21 @@ body {
 }
 
 .month-label {
-  font-size: clamp(2.4rem, 7vw, 3.8rem);
+  font-size: clamp(3rem, 8.2vw, 4.6rem);
   font-weight: 700;
   text-anchor: middle;
   dominant-baseline: middle;
   fill: rgba(0, 0, 0, 0.78);
+}
+
+.month-label .month-number {
+  font-size: 1em;
+}
+
+.month-label .month-suffix {
+  font-size: 0.5em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 body.dark .month-label {

--- a/js/app.js
+++ b/js/app.js
@@ -298,7 +298,17 @@
     monthLabel.setAttribute('x', center);
     monthLabel.setAttribute('y', center);
     monthLabel.setAttribute('aria-hidden', 'true');
-    monthLabel.textContent = `${month + 1}月`;
+
+    const monthNumber = document.createElementNS(svgNS, 'tspan');
+    monthNumber.setAttribute('class', 'month-number');
+    monthNumber.textContent = String(month + 1);
+    monthLabel.appendChild(monthNumber);
+
+    const monthSuffix = document.createElementNS(svgNS, 'tspan');
+    monthSuffix.setAttribute('class', 'month-suffix');
+    monthSuffix.textContent = '月';
+    monthLabel.appendChild(monthSuffix);
+
     svg.appendChild(monthLabel);
 
     ringContainer.innerHTML = '';


### PR DESCRIPTION
## Summary
- render the center month label with separate number and suffix tspans to allow individual styling
- enlarge the month number while shrinking the "月" suffix for clearer emphasis
- update styles so the enlarged month number stays within the calendar layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d15b8facbc8331b2f7d8d256347dc2