### PR TITLE
Remove hover scaling effect from calendar days

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -308,12 +308,7 @@ svg {
 
 .calendar-day {
   cursor: pointer;
-  transition: transform 0.2s ease;
   font-variant-numeric: tabular-nums;
-}
-
-.calendar-day:hover {
-  transform: scale(1.04);
 }
 
 .day-circle {


### PR DESCRIPTION
## Summary
- remove the hover scaling transform from calendar day elements so circles stay fixed under the cursor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d15c0b9688833187e2efc525a31669