### PR TITLE
Move live date/time display into ring center

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,8 +9,6 @@
 </head>
 <body>
   <header class="app-header">
-    <h1>魔琉血悶怒曜尾 ― 環状月暦</h1>
-    <p id="now" class="now" aria-live="polite" aria-atomic="true"></p>
     <nav class="controls" aria-label="月移動">
       <button id="prev" type="button" aria-label="前の月へ">◀ 前月</button>
       <button id="today" type="button">今日へ</button>
@@ -20,15 +18,28 @@
   <main class="app-main">
     <section class="ring-section" aria-labelledby="ring-heading">
       <h2 id="ring-heading" class="sr-only">環状月暦</h2>
-      <div id="ring" class="ring-container" role="img" aria-labelledby="ring-title ring-desc"></div>
+      <div id="ring" class="ring-container" role="img" aria-labelledby="ring-title ring-desc">
+        <div id="ring-center" class="ring-center" aria-live="polite" aria-atomic="true">
+          <div class="ring-month" aria-hidden="true">
+            <span id="ring-month-number" class="ring-month-number">1</span><span class="ring-month-unit">月</span>
+          </div>
+          <div id="ring-date" class="ring-date"></div>
+          <div id="ring-time" class="ring-time"></div>
+        </div>
+      </div>
       <p id="ring-title" class="sr-only"></p>
       <p id="ring-desc" class="sr-only">2,3,5,7日周期の曜日を多重に表示する環状カレンダー</p>
       <div id="fallback-list" class="sr-only"></div>
     </section>
     <aside class="legend-panel" aria-labelledby="legend-heading">
-      <section class="legend" aria-labelledby="legend-heading">
+      <div class="legend-header">
         <h3 id="legend-heading">凡例</h3>
-        <ul>
+        <button id="legend-toggle" class="legend-toggle" type="button" aria-controls="legend-list" aria-expanded="true">
+          凡例を隠す
+        </button>
+      </div>
+      <section class="legend" aria-labelledby="legend-heading">
+        <ul id="legend-list">
           <li><span class="legend-dot legend-two" aria-hidden="true"></span><span>二日周期: 陰・陽</span></li>
           <li><span class="legend-dot legend-three" aria-hidden="true"></span><span>三日周期: 石・鋏・紙</span></li>
           <li><span class="legend-dot legend-five" aria-hidden="true"></span><span>五日周期: 風・雨・雷・雲・霧</span></li>

--- a/css/styles.css
+++ b/css/styles.css
@@ -32,13 +32,6 @@ body {
   font-size: clamp(1.5rem, 3vw + 1rem, 2.5rem);
 }
 
-.now {
-  font-variant-numeric: tabular-nums;
-  font-size: clamp(1.4rem, 4vw, 2.2rem);
-  margin-bottom: 1.25rem;
-  font-weight: 600;
-}
-
 .controls {
   display: inline-flex;
   gap: 0.5rem;
@@ -88,6 +81,56 @@ body {
 .ring-container svg {
   width: 100%;
   height: 100%;
+}
+
+.ring-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  pointer-events: none;
+  width: min(80%, 360px);
+}
+
+.ring-month {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 0.1em;
+  font-size: clamp(3rem, 12vw, 5.5rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.ring-month-number {
+  font-size: 1em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ring-month-unit {
+  font-size: 0.5em;
+  line-height: 1;
+}
+
+.ring-date,
+.ring-time {
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  text-shadow: 0 2px 6px rgba(255, 255, 255, 0.65);
+}
+
+.ring-date {
+  font-size: clamp(1rem, 2.8vw, 1.6rem);
+  font-weight: 600;
+}
+
+.ring-time {
+  font-size: clamp(0.95rem, 2.3vw, 1.35rem);
+  font-weight: 500;
 }
 
 .legend-panel {
@@ -243,31 +286,14 @@ body {
   }
 }
 
-.month-label {
-  font-size: clamp(3rem, 8.2vw, 4.6rem);
-  font-weight: 700;
-  text-anchor: middle;
-  dominant-baseline: middle;
-  fill: rgba(0, 0, 0, 0.78);
-}
-
-.month-label .month-number {
-  font-size: 1em;
-}
-
-.month-label .month-suffix {
-  font-size: 0.5em;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-body.dark .month-label {
-  fill: rgba(255, 255, 255, 0.85);
-}
-
 body.dark {
   background: #0c101a;
   color: #f5f5f5;
+}
+
+body.dark .ring-date,
+body.dark .ring-time {
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.55);
 }
 
 body.dark .legend-panel {

--- a/index.html
+++ b/index.html
@@ -9,8 +9,6 @@
 </head>
 <body>
   <header class="app-header">
-    <h1>魔琉血悶怒曜尾 ― 環状月暦</h1>
-    <p id="now" class="now" aria-live="polite" aria-atomic="true"></p>
     <nav class="controls" aria-label="月移動">
       <button id="prev" type="button" aria-label="前の月へ">◀ 前月</button>
       <button id="today" type="button">今日へ</button>
@@ -20,7 +18,15 @@
   <main class="app-main">
     <section class="ring-section" aria-labelledby="ring-heading">
       <h2 id="ring-heading" class="sr-only">環状月暦</h2>
-      <div id="ring" class="ring-container" role="img" aria-labelledby="ring-title ring-desc"></div>
+      <div id="ring" class="ring-container" role="img" aria-labelledby="ring-title ring-desc">
+        <div id="ring-center" class="ring-center" aria-live="polite" aria-atomic="true">
+          <div class="ring-month" aria-hidden="true">
+            <span id="ring-month-number" class="ring-month-number">1</span><span class="ring-month-unit">月</span>
+          </div>
+          <div id="ring-date" class="ring-date"></div>
+          <div id="ring-time" class="ring-time"></div>
+        </div>
+      </div>
       <p id="ring-title" class="sr-only"></p>
       <p id="ring-desc" class="sr-only">2,3,5,7日周期の曜日を多重に表示する環状カレンダー</p>
       <div id="fallback-list" class="sr-only"></div>


### PR DESCRIPTION
## Summary
- add a center overlay inside the ring to show the current month, date, and time
- style the new overlay so the month numeral dominates while the timestamp fits inside the ring
- update the app script to drive the live clock and keep the month label in sync without clearing the overlay

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d1bf180a908331a4c4f924f9b1a059