### PR TITLE
Fix removal of center text when rendering calendar

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -155,6 +155,7 @@
 
     const svgNS = 'http://www.w3.org/2000/svg';
     const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('class', 'ring-calendar-svg');
     svg.setAttribute('viewBox', `0 0 ${svgSize} ${svgSize}`);
     svg.setAttribute('aria-hidden', 'false');
     svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
@@ -325,7 +326,7 @@
       });
     }
 
-    const existingSvg = ringContainer ? ringContainer.querySelector('svg') : null;
+    const existingSvg = ringContainer ? ringContainer.querySelector('svg.ring-calendar-svg') : null;
     if (existingSvg) {
       existingSvg.remove();
     }


### PR DESCRIPTION
## Summary
- ensure the dynamic calendar SVG is tagged so rerenders remove only it
- avoid deleting the static ring-center SVG that contains the month/date/time labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cd084ea08331864e488a86a6b333