### PR TITLE
Align center display with ring viewBox

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -89,12 +89,13 @@ body {
   left: 50%;
   transform: translate(-50%, -50%);
   pointer-events: none;
-  width: min(80%, 360px);
+  width: 100%;
+  height: 100%;
 }
 
 .ring-center-svg {
   width: 100%;
-  height: auto;
+  height: 100%;
   display: block;
 }
 
@@ -103,7 +104,7 @@ body {
 }
 
 .ring-center-month {
-  font-size: 80px;
+  font-size: 192px;
   font-weight: 700;
   text-anchor: middle;
   dominant-baseline: middle;
@@ -124,16 +125,16 @@ body {
   font-weight: 600;
   paint-order: stroke;
   stroke: rgba(255, 255, 255, 0.65);
-  stroke-width: 4;
+  stroke-width: 12;
   stroke-linejoin: round;
 }
 
 .ring-center-date {
-  font-size: 22px;
+  font-size: 66px;
 }
 
 .ring-center-time {
-  font-size: 20px;
+  font-size: 60px;
   font-weight: 500;
 }
 

--- a/index.html
+++ b/index.html
@@ -23,15 +23,15 @@
           <svg
             id="ring-center-svg"
             class="ring-center-svg"
-            viewBox="0 0 200 200"
+            viewBox="0 0 600 600"
             preserveAspectRatio="xMidYMid meet"
           >
-            <text id="ring-center-month" class="ring-center-month" x="100" y="90" aria-hidden="true">
+            <text id="ring-center-month" class="ring-center-month" x="300" y="270" aria-hidden="true">
               <tspan id="ring-month-number" class="ring-center-month-number">1</tspan>
-              <tspan class="ring-center-month-unit" dx="6">月</tspan>
+              <tspan class="ring-center-month-unit" dx="18">月</tspan>
             </text>
-            <text id="ring-date" class="ring-center-date" x="100" y="125"></text>
-            <text id="ring-time" class="ring-center-time" x="100" y="150"></text>
+            <text id="ring-date" class="ring-center-date" x="300" y="375"></text>
+            <text id="ring-time" class="ring-center-time" x="300" y="450"></text>
           </svg>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- match the ring center SVG viewBox and coordinates to the main calendar ring
- scale the center text placement and stroke widths to align with the resized viewBox
- ensure the center overlay fills the ring container so zoom and font changes stay centered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1d0afdd008331a82955a38e4e0fac