### PR TITLE
Display year above month in ring center

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -256,6 +256,14 @@ body {
   fill: currentColor;
 }
 
+.ring-center-year {
+  font-size: 28px;
+  font-weight: 600;
+  text-anchor: middle;
+  dominant-baseline: alphabetic;
+  opacity: 0.75;
+}
+
 .ring-center-month {
   font-size: 120px;
   font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
               <tspan id="ring-month-number" class="ring-center-month-number">1</tspan>
               <tspan class="ring-center-month-unit" dx="-30">月</tspan>
             </text>
+            <text id="ring-year" class="ring-center-year" x="300" y="255" aria-hidden="true"></text>
             <text id="ring-date" class="ring-center-date" x="300" y="350"></text>
             <text id="ring-time" class="ring-center-time" x="300" y="380"></text>
           </svg>

--- a/js/app.js
+++ b/js/app.js
@@ -23,6 +23,7 @@
 
   const ringContainer = document.getElementById('ring');
   const ringCenter = document.getElementById('ring-center');
+  const ringYearEl = document.getElementById('ring-year');
   const ringMonthNumberEl = document.getElementById('ring-month-number');
   const ringDateEl = document.getElementById('ring-date');
   const ringTimeEl = document.getElementById('ring-time');
@@ -646,6 +647,9 @@
   }
 
   function updateCenterMonth(year, month) {
+    if (ringYearEl) {
+      setNodeText(ringYearEl, `${year}年`);
+    }
     if (ringMonthNumberEl) {
       setNodeText(ringMonthNumberEl, String(month + 1));
     }


### PR DESCRIPTION
## Summary
- add a dedicated SVG text node in the ring center to show the active year
- style the year label so it appears smaller above the month number
- keep the year text in sync with the viewed month in the calendar logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1ef62afc08331b300a85a14e99879